### PR TITLE
Add alaram driver interface to hal

### DIFF
--- a/Inc/HAL/Alarm.h
+++ b/Inc/HAL/Alarm.h
@@ -18,3 +18,8 @@
 
 #define ALARM_NUM_BLINKS 6
 void Alarm_init();
+
+void Alarm_correctID_on(void);
+void Alarm_correctID_off(void);
+void Alarm_correctID_blink(void);
+

--- a/Inc/HAL/Alarm.h
+++ b/Inc/HAL/Alarm.h
@@ -23,3 +23,11 @@ void Alarm_correctID_on(void);
 void Alarm_correctID_off(void);
 void Alarm_correctID_blink(void);
 
+void Alarm_wrongID_on(void);
+void Alarm_wrongID_off(void);
+void Alarm_wrongID_blink(void);
+
+
+
+
+#endif /* HAL_ALARM_H_ */

--- a/Inc/HAL/Alarm.h
+++ b/Inc/HAL/Alarm.h
@@ -1,0 +1,20 @@
+/*
+ * Alarm.h
+ *
+ *  Created on: Jul 26, 2023
+ *      Author: Ziad Gamalelden
+ */
+
+#ifndef HAL_ALARM_H_
+#define HAL_ALARM_H_
+
+#include "MCAL/Stm32_F103C6_GPIO.h"
+
+#define ALARM_CORRECID_PORT GPIOA
+#define ALARM_CORRECID_PIN GPIO_PIN_11
+
+#define ALARM_WRONGID_PORT GPIOA
+#define ALARM_WRONGID_PIN GPIO_PIN_0
+
+#define ALARM_NUM_BLINKS 6
+void Alarm_init();

--- a/Inc/HAL/Alarm.h
+++ b/Inc/HAL/Alarm.h
@@ -1,8 +1,12 @@
-/*
- * Alarm.h
+/**
+ * @file Alarm.h
+ * @brief Header file for an alarm system with LED indicators for correct and wrong IDs.
  *
- *  Created on: Jul 26, 2023
- *      Author: Ziad Gamalelden
+ * This file contains function prototypes and constants to control the alarm system LEDs.
+ * The system has LED indicators to show correct ID and wrong ID events.
+ *
+ * @author Ziad Gamalelden
+ * @date July 26, 2023
  */
 
 #ifndef HAL_ALARM_H_
@@ -10,24 +14,81 @@
 
 #include "MCAL/Stm32_F103C6_GPIO.h"
 
+/** @defgroup Alarm_GPIO Alarm GPIO Pins
+ * @{ */
+
+/** @brief GPIO port for the correct ID LED. */
 #define ALARM_CORRECID_PORT GPIOA
+/** @brief GPIO pin for the correct ID LED. */
 #define ALARM_CORRECID_PIN GPIO_PIN_11
 
+/** @brief GPIO port for the wrong ID LED. */
 #define ALARM_WRONGID_PORT GPIOA
+/** @brief GPIO pin for the wrong ID LED. */
 #define ALARM_WRONGID_PIN GPIO_PIN_0
 
+/** @} */
+
+/** @defgroup Alarm_Config Alarm Configuration
+ * @{ */
+
+/** @brief Number of blinks for alarm LEDs (blinks every ALARM_BLINK_MS). */
 #define ALARM_NUM_BLINKS 6
+/** @brief Time of every blink for alarm LEDs. */
+#define ALARM_BLINK_MS 50
+
+/** @} */
+
+/**
+ * @brief Initializes the alarm system.
+ *
+ * This function should be called before using any other alarm-related functions.
+ * It initializes the GPIO pins for the correct and wrong ID LEDs.
+ */
 void Alarm_init();
 
+/**
+ * @brief Turns on the correct ID LED.
+ *
+ * This function turns on the correct ID LED, indicating that the ID is correct.
+ */
 void Alarm_correctID_on(void);
+
+/**
+ * @brief Turns off the correct ID LED.
+ *
+ * This function turns off the correct ID LED, indicating that the ID is no longer correct.
+ */
 void Alarm_correctID_off(void);
+
+/**
+ * @brief Blinks the correct ID LED.
+ *
+ * This function blinks the correct ID LED a specified number of times with a ALARM_BLINK_MS duration per blink.
+ * The number of blinks and duration are specified by the constants ALARM_NUM_BLINKS and ALARM_BLINK_MS, respectively.
+ */
 void Alarm_correctID_blink(void);
 
+/**
+ * @brief Turns on the wrong ID LED.
+ *
+ * This function turns on the wrong ID LED, indicating that the ID is wrong.
+ */
 void Alarm_wrongID_on(void);
+
+/**
+ * @brief Turns off the wrong ID LED.
+ *
+ * This function turns off the wrong ID LED, indicating that the ID is no longer wrong.
+ */
 void Alarm_wrongID_off(void);
+
+/**
+ * @brief Blinks the wrong ID LED.
+ *
+ * This function blinks the wrong ID LED a specified number of times with a ALARM_BLINK_MS duration per blink.
+ * The number of blinks and duration are specified by the constants ALARM_NUM_BLINKS and ALARM_BLINK_MS, respectively.
+ */
 void Alarm_wrongID_blink(void);
-
-
-
 
 #endif /* HAL_ALARM_H_ */

--- a/Src/HAL/Alarm.c
+++ b/Src/HAL/Alarm.c
@@ -1,0 +1,28 @@
+/*
+ * Alarm.c
+ *
+ *  Created on: Jul 26, 2023
+ *  Author: Ziad Gamalelden
+ */
+
+#include "HAL/Alarm.h"
+#include "MCAL/Stm32_F103C6_Timer.h"
+
+void Alarm_init(void)
+{
+	GPIO_PinConfig_t PinConfig;
+	PinConfig.GPIO_Mode = GPIO_MODE_OUTPUT_PP;
+	PinConfig.GPIO_Speed = GPIO_SPEED_10M;
+
+	// CorrecID LED
+	PinConfig.GPIO_PinNumber= ALARM_CORRECID_PIN;
+	MCAL_GPIO_Init(ALARM_CORRECID_PORT, &PinConfig);
+
+	// WrongID LED
+	PinConfig.GPIO_PinNumber= ALARM_WRONGID_PIN;
+	MCAL_GPIO_Init(ALARM_WRONGID_PORT, &PinConfig);
+
+	// Turn off LEDS
+	MCAL_GPIO_WritePin(ALARM_CORRECID_PORT, ALARM_CORRECID_PIN, GPIO_PIN_SET);
+	MCAL_GPIO_WritePin(ALARM_WRONGID_PORT, ALARM_WRONGID_PIN, GPIO_PIN_SET);
+}

--- a/Src/HAL/Alarm.c
+++ b/Src/HAL/Alarm.c
@@ -48,3 +48,24 @@ void Alarm_correctID_blink(void)
 	MCAL_GPIO_WritePin(ALARM_CORRECID_PORT, ALARM_CORRECID_PIN, GPIO_PIN_RESET);
 }
 
+void Alarm_wrongID_on(void)
+{
+	MCAL_GPIO_WritePin(ALARM_WRONGID_PORT, ALARM_WRONGID_PIN, GPIO_PIN_RESET);
+
+}
+void Alarm_wrongID_off(void)
+{
+	MCAL_GPIO_WritePin(ALARM_WRONGID_PORT, ALARM_WRONGID_PIN, GPIO_PIN_SET);
+
+}
+
+void Alarm_wrongID_blink(void)
+{
+	uint8_t blinks;
+	for(blinks = 0; blinks < ALARM_NUM_BLINKS; blinks++)
+	{
+		MCAL_GPIO_TogglePin(ALARM_WRONGID_PORT, ALARM_WRONGID_PIN);
+		MCAL_Timer2_dms(50);
+	}
+	MCAL_GPIO_WritePin(ALARM_WRONGID_PORT, ALARM_WRONGID_PIN, GPIO_PIN_RESET);
+}

--- a/Src/HAL/Alarm.c
+++ b/Src/HAL/Alarm.c
@@ -26,3 +26,25 @@ void Alarm_init(void)
 	MCAL_GPIO_WritePin(ALARM_CORRECID_PORT, ALARM_CORRECID_PIN, GPIO_PIN_SET);
 	MCAL_GPIO_WritePin(ALARM_WRONGID_PORT, ALARM_WRONGID_PIN, GPIO_PIN_SET);
 }
+
+void Alarm_correctID_on(void)
+{
+	MCAL_GPIO_WritePin(ALARM_CORRECID_PORT, ALARM_CORRECID_PIN, GPIO_PIN_RESET);
+}
+
+void Alarm_correctID_off(void)
+{
+	MCAL_GPIO_WritePin(ALARM_CORRECID_PORT, ALARM_CORRECID_PIN, GPIO_PIN_SET);
+}
+
+void Alarm_correctID_blink(void)
+{
+	uint8_t blinks;
+	for(blinks = 0; blinks < ALARM_NUM_BLINKS; blinks++)
+	{
+		MCAL_GPIO_TogglePin(ALARM_CORRECID_PORT, ALARM_CORRECID_PIN);
+		MCAL_Timer2_dms(50);
+	}
+	MCAL_GPIO_WritePin(ALARM_CORRECID_PORT, ALARM_CORRECID_PIN, GPIO_PIN_RESET);
+}
+

--- a/Src/HAL/PIR.c
+++ b/Src/HAL/PIR.c
@@ -25,8 +25,8 @@ void PIR_init(void)
 	PinConfig.GPIO_PinNumber= PIR_EXIT_PIN;
 	MCAL_GPIO_Init(GPIOA, &PinConfig);
 
-	MCAL_GPIO_WritePin(PIR_GPIOx, PIR_ENTRY_PIN, GPIO_PIN_SET); //make A0 ground
-	MCAL_GPIO_WritePin(PIR_GPIOx, PIR_EXIT_PIN, GPIO_PIN_SET); //make A11 ground
+	MCAL_GPIO_WritePin(PIR_GPIOx, PIR_ENTRY_PIN, GPIO_PIN_SET);
+	MCAL_GPIO_WritePin(PIR_GPIOx, PIR_EXIT_PIN, GPIO_PIN_SET);
 }
 
 e_PIRStatus_t PIR_entry(void)

--- a/Src/main.c
+++ b/Src/main.c
@@ -11,7 +11,7 @@
 #include "HAL/Keypad.h"
 #include "HAL/Servo_Motor.h"
 #include "HAL/PIR.h"
-
+#include "HAL/Alarm.h"
 void clock_init()
 {
 	// Using internal 8 MHz RC oscillator
@@ -28,6 +28,7 @@ void clock_init()
 	Servo1_Entry_Gate_Init();
 	Servo2_Exit_Gate_Init();
 	PIR_init();
+	Alarm_init();
 
 
 
@@ -50,14 +51,23 @@ void x(void)
 	if(ch == '1')
 	{
 		Servo1_Entry_Gate(SERVO_UP);
+		Alarm_correctID_blink();
 	}
 	else if(ch == '0')
 	{
 		if(PIR_exit() == PIR_NOT_DETECTED)
 		{
 			Servo1_Entry_Gate(SERVO_DOWN);
+			Alarm_correctID_blink();
+			Alarm_correctID_off();
 
 		}
+	}
+	else
+	{
+		Alarm_wrongID_blink();
+		Alarm_wrongID_off();
+
 	}
 
 	MCAL_UART_SendData(USART1, &ch, enable);
@@ -110,7 +120,6 @@ int main(void)
 	MCAL_UART_GPIO_Set_Pins(USART2);
 
 
-	char x = 0;
 	while(1)
 	{
 


### PR DESCRIPTION
## Added Alaram driver in HAL 
## Test code used
```C
// Learn-in-depth
// Ziad Ashraf
// Mastering_Embedded System online diploma

#include "MCAL/stm32f103x6.h"
#include "MCAL/Stm32_F103C6_EXTI.h"
#include "MCAL/Stm32_F103C6_GPIO.h"
#include "MCAL/Stm32_F103C6_USART.h"
#include "MCAL/Stm32_F103C6_Timer.h"
#include "HAL/LCD.h"
#include "HAL/Keypad.h"
#include "HAL/Servo_Motor.h"
#include "HAL/PIR.h"
#include "HAL/Alarm.h"
void clock_init()
{
	// Using internal 8 MHz RC oscillator
	RCC_GPIOA_CLK_EN();
	RCC_GPIOB_CLK_EN();
	RCC_AFIO_CLK_EN();
	MCAL_Timer2_init();


	LCD_init(&LCD_admin);
	LCD_init(&LCD_entry);

	KPAD_init();
	Servo1_Entry_Gate_Init();
	Servo2_Exit_Gate_Init();
	PIR_init();
	Alarm_init();



}

void delay(int a)
{
	for(int i = 0; i < a; i++)
	{
		for(int j = 0; j < 255; j++);
	}
}


uint16_t ch = '5';
uint16_t ch2 = '6';
void x(void)
{
	MCAL_UART_ReceiveData(USART1, &ch, disable);
	if(ch == '1')
	{
		Servo1_Entry_Gate(SERVO_UP);
		Alarm_correctID_blink();
	}
	else if(ch == '0')
	{
		if(PIR_exit() == PIR_NOT_DETECTED)
		{
			Servo1_Entry_Gate(SERVO_DOWN);
			Alarm_correctID_blink();
			Alarm_correctID_off();

		}
	}
	else
	{
		Alarm_wrongID_blink();
		Alarm_wrongID_off();

	}

	MCAL_UART_SendData(USART1, &ch, enable);

}

void yfunc(void)
{
	MCAL_UART_ReceiveData(USART2, &ch2, disable);
	LCD_clearscreen(&LCD_entry);
	LCD_sendstring(&LCD_entry, (char*)"Welcome bro");
	LCD_gotoxy(&LCD_entry, 0, 1);
	LCD_sendstring(&LCD_entry, (char*)"Name: ");
	LCD_gotoxy(&LCD_entry, 0, 2);
	LCD_sendstring(&LCD_entry, (char*)"Age: ");
	LCD_gotoxy(&LCD_entry, 0, 3);
	LCD_sendstring(&LCD_entry, (char*)"Degree: ");

	MCAL_UART_SendData(USART2, (uint16_t*)&x, enable);

}
int main(void)
{

	clock_init();
	USART_Config_t uart_config;
	uart_config.BaudRate = UART_BaudRate_115200;
	uart_config.HwFlowCtl = UART_HwFlowCtl_NONE;
	uart_config.IRQ_Enable = UART_IRQ_Enable_RXNEIE;
	uart_config.P_IRQ_CallBack = x;
	uart_config.Parity = UART_Parity_NONE;
	uart_config.Payload_Length = UART_Payload_Length_8B;
	uart_config.StopBits = UART_StopBits_1;
	uart_config.USART_Mode = UART_Mode_TX_RX;
	MCAL_UART_Init(USART1, &uart_config);
	MCAL_UART_GPIO_Set_Pins(USART1);


	USART_Config_t uart2CFG;

	uart2CFG.BaudRate = UART_BaudRate_115200;
	uart2CFG.HwFlowCtl = UART_HwFlowCtl_NONE;
	uart2CFG.IRQ_Enable = UART_IRQ_Enable_NONE;
	uart2CFG.P_IRQ_CallBack = yfunc;
	uart2CFG.Parity = UART_Parity_NONE;
	uart2CFG.Payload_Length = UART_Payload_Length_8B;
	uart2CFG.StopBits = UART_StopBits_1;
	uart2CFG.USART_Mode = UART_Mode_TX_RX;
	MCAL_UART_Init(USART2, &uart2CFG);
	MCAL_UART_GPIO_Set_Pins(USART2);


	while(1)
	{


	}

}

```